### PR TITLE
release-1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <description>When a synchronization request is made, the response value is a JOPO object that is not wrapped by the Call Class of Retrofit, and this JOPO object has the same structure as the returned value of the called API</description>
     <artifactId>adapter-simple-body</artifactId>
+    <name>adapter-simple-body</name>
     <version>1.2.0</version>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
移除了ErrorResponseBody的处理,
这个功能交给了调用者自己根据业务进行处理.